### PR TITLE
Migrate site to Chirpy theme + add blog structure

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,50 @@
+name: Deploy Jekyll site to GitHub Pages
+
+on:
+  push:
+    branches: [ master ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Build with Jekyll
+        run: bundle exec jekyll build --destination _site
+        env:
+          JEKYLL_ENV: production
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "jekyll", "~> 4.3"
+
+gem "jekyll-remote-theme"
+gem "jekyll-include-cache"
+gem "jekyll-seo-tag"
+gem "jekyll-sitemap"
+gem "jekyll-feed"
+gem "jekyll-paginate"

--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# mo's blog
+
+This repository powers https://mmoradi97.github.io.
+
+## Local development
+1. Install Ruby and Bundler
+2. Run `bundle install`
+3. Run `bundle exec jekyll serve`
+
+## Deployment
+GitHub Actions builds and deploys the site to GitHub Pages.

--- a/_config.yml
+++ b/_config.yml
@@ -1,10 +1,39 @@
 title: "Mo's Blog"
 tagline: "Notes, projects, and updates."
-description: "Personal blog and updates."
+description: "Personal website and blog: notes, project writeups, and updates."
 
 url: "https://mmoradi97.github.io"
 baseurl: ""
 
-remote_theme: pages-themes/midnight@v0.2.0
+lang: en
+timezone: Europe/Warsaw
+
+github:
+  username: mmoradi97
+
+social:
+  name: Mo Moradi
+  links:
+    - https://github.com/mmoradi97
+
+# Chirpy theme
+remote_theme: cotes2020/jekyll-theme-chirpy
+
 plugins:
   - jekyll-remote-theme
+  - jekyll-include-cache
+  - jekyll-seo-tag
+  - jekyll-sitemap
+  - jekyll-feed
+  - jekyll-paginate
+
+paginate: 8
+
+defaults:
+  - scope:
+      path: ""
+      type: posts
+    values:
+      layout: post
+      toc: true
+      comments: false

--- a/_config.yml
+++ b/_config.yml
@@ -29,6 +29,11 @@ plugins:
 
 paginate: 8
 
+collections:
+  tabs:
+    output: true
+    sort_by: order
+
 defaults:
   - scope:
       path: ""
@@ -37,3 +42,13 @@ defaults:
       layout: post
       toc: true
       comments: false
+
+# Prevent legacy files from overriding the Chirpy theme
+exclude:
+  - _includes
+  - _layouts
+  - assets/css/style.scss
+  - about.md
+  - projects.md
+  - contact.md
+  - thank-you.md

--- a/_posts/2026-02-07-welcome.md
+++ b/_posts/2026-02-07-welcome.md
@@ -1,7 +1,10 @@
 ---
-layout: default
 title: "Welcome"
 date: 2026-02-07 21:00:00 +0100
+categories: [site]
+tags: [welcome, jekyll]
 ---
 
-this is my first post
+Welcome to my blog.
+
+I’ll use this space for short notes and project writeups. For now, this is the first post to make sure everything is wired up correctly.

--- a/_posts/2026-02-12-site-stack.md
+++ b/_posts/2026-02-12-site-stack.md
@@ -1,0 +1,14 @@
+---
+title: "How this site works"
+date: 2026-02-12 20:00:00 +0100
+categories: [site]
+tags: [jekyll, github-pages]
+---
+
+This site is built with Jekyll and hosted on GitHub Pages.
+
+## Content
+Posts live in `_posts/` and use Markdown.
+
+## Theme
+I’m using the Chirpy theme to get a clean, blog-like layout with archives, tags, and categories.

--- a/_posts/2026-02-15-now.md
+++ b/_posts/2026-02-15-now.md
@@ -1,0 +1,16 @@
+---
+title: "What I’m building right now"
+date: 2026-02-15 10:00:00 +0100
+categories: [updates]
+tags: [now]
+---
+
+A quick snapshot of what I’m focusing on.
+
+## Current priorities
+- Improve this website’s structure and design
+- Publish a few practical engineering notes
+- Document projects with clear before/after results
+
+## Next
+I’ll add a proper Projects section with short case studies and links.

--- a/_tabs/about.md
+++ b/_tabs/about.md
@@ -1,0 +1,21 @@
+---
+title: About
+icon: fas fa-user
+order: 1
+layout: page
+---
+
+Hi, I’m Mo.
+
+I use this site to publish short notes, project writeups, and things I learn while building.
+
+## What you’ll find here
+- Engineering notes (practical, copy/paste-friendly)
+- Project writeups (what I built, trade-offs, results)
+- Occasional updates
+
+## Now
+I’m currently focusing on building a clean personal site and turning it into a consistent blog.
+
+## Links
+- GitHub: https://github.com/mmoradi97

--- a/_tabs/archives.md
+++ b/_tabs/archives.md
@@ -1,0 +1,6 @@
+---
+title: Archives
+icon: fas fa-archive
+order: 4
+layout: archives
+---

--- a/_tabs/categories.md
+++ b/_tabs/categories.md
@@ -1,0 +1,6 @@
+---
+title: Categories
+icon: fas fa-stream
+order: 5
+layout: categories
+---

--- a/_tabs/contact.md
+++ b/_tabs/contact.md
@@ -1,0 +1,12 @@
+---
+title: Contact
+icon: fas fa-envelope
+order: 3
+layout: page
+---
+
+The simplest way to reach me is via GitHub.
+
+- GitHub: https://github.com/mmoradi97
+
+If you want, I can add a proper email link and a lightweight contact form once you confirm where you want messages delivered (email, Formspree, Netlify Forms, etc.).

--- a/_tabs/projects.md
+++ b/_tabs/projects.md
@@ -1,0 +1,14 @@
+---
+title: Projects
+icon: fas fa-code
+order: 2
+layout: page
+---
+
+A few things I’ve built or I’m working on.
+
+## Featured
+1. This website (Jekyll + GitHub Pages)
+
+## More
+For the full list, check my GitHub profile: https://github.com/mmoradi97

--- a/_tabs/tags.md
+++ b/_tabs/tags.md
@@ -1,0 +1,6 @@
+---
+title: Tags
+icon: fas fa-tags
+order: 6
+layout: tags
+---

--- a/index.md
+++ b/index.md
@@ -1,22 +1,4 @@
 ---
-layout: default
-title: Home
+layout: home
+# Index page
 ---
-
-<div class="hero">
-  <p class="kicker">Personal blog & updates</p>
-  <h1>Mo’s Blog</h1>
-  <p class="lead">Notes, projects, and short writeups. Built with Jekyll + GitHub Pages.</p>
-</div>
-
-<h2>Latest posts</h2>
-<ul class="post-list">
-  {% for post in site.posts limit: 8 %}
-    <li>
-      <a href="{{ post.url }}">{{ post.title }}</a>
-      <span class="meta">{{ post.date | date: "%Y-%m-%d" }}</span>
-    </li>
-  {% endfor %}
-</ul>
-
-<p class="home-note">More links (About / Projects / Contact / RSS) are in the footer.</p>


### PR DESCRIPTION
This PR migrates the site to the **Chirpy** Jekyll theme and adds a more blog-like structure.

What’s included:
- Switch to `cotes2020/jekyll-theme-chirpy` via `remote_theme`
- Add `_tabs/` navigation pages (About / Projects / Contact / Archives / Categories / Tags)
- Update the existing welcome post and add a couple starter posts
- Add a GitHub Pages deployment workflow (`.github/workflows/pages.yml`)
- Add a `Gemfile` for local dev / CI

Notes:
- I added an `exclude:` list in `_config.yml` so your previous custom `_includes`, `_layouts`, and `assets/css/style.scss` don’t override Chirpy.
- After merge, set **Settings → Pages → Source** to **GitHub Actions** (so the included workflow deploys).

If you want, next we can:
- Fill in About/Projects with real content
- Add a proper contact method (email / form)
- Add a nicer homepage intro + featured posts
