### PR TITLE
Fix Chirpy build: use theme layouts/includes + add head-custom

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -29,6 +29,12 @@ plugins:
   - jekyll-archives
 
 paginate: 8
+paginate_path: /page:num/
+
+# IMPORTANT: prevent legacy repo files from overriding Chirpy.
+# (This repo previously had its own _layouts/ and _includes/.)
+layouts_dir: _layouts_chirpy
+includes_dir: _includes_chirpy
 
 collections:
   tabs:
@@ -44,7 +50,6 @@ defaults:
       toc: true
       comments: false
 
-# Prevent legacy files from overriding the Chirpy theme
 exclude:
   - _includes
   - _layouts

--- a/_includes_chirpy/head-custom.html
+++ b/_includes_chirpy/head-custom.html
@@ -1,0 +1,5 @@
+<!--
+  This file is intentionally left minimal.
+  Chirpy's layouts include `head-custom.html` as an extension point.
+  Add custom meta tags, analytics, or extra CSS here later.
+-->


### PR DESCRIPTION
This fixes the current build error:

> Liquid Exception: Could not locate the included file 'head-custom.html' ... in /_layouts/default.html

Root cause
- The repo still contains legacy `_layouts/default.html` and `_includes/` from the old theme.
- Those local folders override the Chirpy theme’s layouts/includes and cause the missing `head-custom.html` include.

Fix
- Point Jekyll to use *new* site layout/include directories (`_layouts_chirpy`, `_includes_chirpy`) so the legacy folders no longer override the theme.
- Add `_includes_chirpy/head-custom.html` (Chirpy extension hook).
- Add `paginate_path` to align with typical pagination paths.

After merge, re-run the Pages workflow; it should build with Chirpy’s layouts and no longer error on `head-custom.html`.
