### PR TITLE
Fix build: use Chirpy theme gem (no remote_theme) + index.html pagination

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/configure-pages@v5
 
       - name: Build with Jekyll
-        run: bundle exec jekyll build --destination _site
+        run: bundle exec jekyll build --destination _site --trace
         env:
           JEKYLL_ENV: production
 

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,8 @@ source "https://rubygems.org"
 
 gem "jekyll", "~> 4.3"
 
-gem "jekyll-remote-theme"
+gem "jekyll-theme-chirpy"
+
 gem "jekyll-include-cache"
 gem "jekyll-seo-tag"
 gem "jekyll-sitemap"

--- a/_config.yml
+++ b/_config.yml
@@ -16,11 +16,10 @@ social:
   links:
     - https://github.com/mmoradi97
 
-# Chirpy theme
-remote_theme: cotes2020/jekyll-theme-chirpy
+# Chirpy theme (use the theme gem, not remote_theme)
+theme: jekyll-theme-chirpy
 
 plugins:
-  - jekyll-remote-theme
   - jekyll-include-cache
   - jekyll-seo-tag
   - jekyll-sitemap
@@ -58,3 +57,4 @@ exclude:
   - projects.md
   - contact.md
   - thank-you.md
+  - index.md

--- a/index.html
+++ b/index.html
@@ -1,0 +1,4 @@
+---
+layout: home
+# Index page
+---

--- a/index.md
+++ b/index.md
@@ -1,4 +1,7 @@
 ---
-layout: home
-# Index page
+layout: default
+permalink: /_legacy-home/
 ---
+
+This page is kept only to avoid breaking existing links.
+The homepage is now powered by `index.html` for proper pagination support.


### PR DESCRIPTION
This PR fixes the current build error (`undefined method 'version' for Jekyll::RemoteTheme::MockGemspec`) by switching Chirpy from `remote_theme` to the published theme gem.

Changes
- Use `theme: jekyll-theme-chirpy` instead of `remote_theme`
- Replace `jekyll-remote-theme` with `jekyll-theme-chirpy` in `Gemfile`
- Add `index.html` as the homepage to satisfy Jekyll pagination (previously `index.md` caused a pagination warning)
- Keep `index.md` but move it to a non-root permalink (`/_legacy-home/`) and exclude it from the build
- Add `--trace` to the build command in the Pages workflow for better diagnostics if anything breaks later

Cleanup / stability
- Continue routing Jekyll to `_layouts_chirpy` and `_includes_chirpy` so legacy `_layouts/` and `_includes/` in the repo can’t override Chirpy.
