### PR TITLE
Add sidebar avatar (Chirpy)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -16,6 +16,9 @@ social:
   links:
     - https://github.com/mmoradi97
 
+# Sidebar avatar (use a hosted image for now)
+avatar: "https://avatars.githubusercontent.com/u/72094509?v=4"
+
 # Chirpy theme (use the theme gem, not remote_theme)
 theme: jekyll-theme-chirpy
 


### PR DESCRIPTION
Adds a sidebar avatar for the Chirpy theme.

- Sets `avatar` in `_config.yml` to your GitHub-hosted profile image URL (no image files committed yet).
- Does not change favicon yet (keeps current behavior).

If you later want a custom local avatar file instead of the GitHub URL, we can add `assets/img/avatar.png` and point `avatar` to it.
