### PR TITLE
Add contact email mailto + override favicon

### DIFF
--- a/_includes_chirpy/head-custom.html
+++ b/_includes_chirpy/head-custom.html
@@ -1,5 +1,10 @@
 <!--
-  This file is intentionally left minimal.
-  Chirpy's layouts include `head-custom.html` as an extension point.
-  Add custom meta tags, analytics, or extra CSS here later.
+  Custom additions to <head>.
+
+  Favicon:
+  For now we intentionally override the theme favicon with an “empty” favicon
+  (so browsers don't show the default Chirpy icon).
+  Replace these later with real favicon files.
 -->
+<link rel="icon" href="data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27/%3E">
+<link rel="apple-touch-icon" href="data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27/%3E">

--- a/_tabs/contact.md
+++ b/_tabs/contact.md
@@ -5,8 +5,9 @@ order: 3
 layout: page
 ---
 
-The simplest way to reach me is via GitHub.
+You can reach me here:
 
+- Email: [mmoradi97@icloud.com](mailto:mmoradi97@icloud.com)
 - GitHub: https://github.com/mmoradi97
 
-If you want, I can add a proper email link and a lightweight contact form once you confirm where you want messages delivered (email, Formspree, Netlify Forms, etc.).
+(If you prefer, I can add a lightweight contact form later—Formspree/Netlify Forms/etc.)


### PR DESCRIPTION
Adds an email link to the Contact page and removes the default Chirpy favicon.

Changes
- Contact page: adds `mailto:mmoradi97@icloud.com`
- Head custom: overrides the theme favicon with an empty SVG data-URI favicon (so the tab icon is no longer the default)

Follow-up (optional)
- Later we can add real favicon files under `assets/img/favicons/` and replace the data-URI links.
