### PR TITLE
Fix favicon override + modernize Contact form styling

### DIFF
--- a/_includes_chirpy/head-custom.html
+++ b/_includes_chirpy/head-custom.html
@@ -2,9 +2,12 @@
   Custom additions to <head>.
 
   Favicon:
-  For now we intentionally override the theme favicon with an “empty” favicon
-  (so browsers don't show the default Chirpy icon).
-  Replace these later with real favicon files.
+  Some browsers ignore empty SVG data-URIs, so we explicitly override the theme's
+  favicon links with `data:,` (a standard “empty” favicon).
+
+  If you want a real favicon later, we can replace these with actual files.
 -->
-<link rel="icon" href="data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27/%3E">
-<link rel="apple-touch-icon" href="data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27/%3E">
+<link rel="icon" href="data:,">
+<link rel="shortcut icon" href="data:,">
+<link rel="apple-touch-icon" href="data:,">
+<meta name="msapplication-TileImage" content="data:,">

--- a/_tabs/contact.md
+++ b/_tabs/contact.md
@@ -7,29 +7,62 @@ layout: page
 
 [mmoradi97@icloud.com](mailto:mmoradi97@icloud.com)
 
-<form action="https://formspree.io/f/mreagwkd" method="POST">
-  <p>
-    <label>
-      Name<br>
-      <input type="text" name="name" required>
-    </label>
-  </p>
+<style>
+  /* Minimal styling for the embedded Formspree form (works even without any CSS framework). */
+  .contact-form {
+    max-width: 520px;
+  }
+  .contact-form .field {
+    margin: 0 0 1rem 0;
+  }
+  .contact-form label {
+    display: block;
+    font-weight: 600;
+    margin: 0 0 0.35rem 0;
+  }
+  .contact-form input,
+  .contact-form textarea {
+    width: 100%;
+    padding: 0.75rem 0.9rem;
+    border-radius: 0.5rem;
+    border: 1px solid rgba(255, 255, 255, 0.18);
+    background: rgba(255, 255, 255, 0.04);
+    color: inherit;
+    outline: none;
+  }
+  .contact-form input:focus,
+  .contact-form textarea:focus {
+    border-color: rgba(255, 255, 255, 0.35);
+  }
+  .contact-form button {
+    padding: 0.65rem 1.0rem;
+    border-radius: 0.55rem;
+    border: 1px solid rgba(255, 255, 255, 0.25);
+    background: rgba(255, 255, 255, 0.08);
+    color: inherit;
+    font-weight: 600;
+    cursor: pointer;
+  }
+  .contact-form button:hover {
+    background: rgba(255, 255, 255, 0.12);
+  }
+</style>
 
-  <p>
-    <label>
-      Email<br>
-      <input type="email" name="email" required>
-    </label>
-  </p>
+<form class="contact-form" action="https://formspree.io/f/mreagwkd" method="POST">
+  <div class="field">
+    <label for="name">Name</label>
+    <input id="name" name="name" type="text" autocomplete="name" required>
+  </div>
 
-  <p>
-    <label>
-      Message<br>
-      <textarea name="message" rows="6" required></textarea>
-    </label>
-  </p>
+  <div class="field">
+    <label for="email">Email</label>
+    <input id="email" name="email" type="email" autocomplete="email" required>
+  </div>
 
-  <p>
-    <button type="submit">Send</button>
-  </p>
+  <div class="field">
+    <label for="message">Message</label>
+    <textarea id="message" name="message" rows="6" required></textarea>
+  </div>
+
+  <button type="submit">Send</button>
 </form>


### PR DESCRIPTION
Addresses two issues:

1) Favicon still showing
- Replaces the previous empty-SVG favicon override with `data:,` link tags, which is more broadly respected by browsers.

2) Formspree form styling
- Updates the Contact tab to use cleaner markup and a small embedded CSS block for a modern look, while keeping the page content to only your email + the form.

No favicon files are added; this keeps the “no favicon” intent for now.
