### PR TITLE
Fix Contact styling in forced light mode + improve typography

### DIFF
--- a/_tabs/contact.md
+++ b/_tabs/contact.md
@@ -5,24 +5,63 @@ order: 3
 layout: page
 ---
 
-**Email:**
+<div class="contact-block">
+  <div class="contact-section">
+    <div class="contact-section-title">Email:</div>
+    <div class="contact-email">
+      <a href="mailto:mmoradi97@icloud.com">mmoradi97@icloud.com</a>
+    </div>
+  </div>
 
-[mmoradi97@icloud.com](mailto:mmoradi97@icloud.com)
+  <div class="contact-section">
+    <div class="contact-section-title">Form:</div>
 
-**Form:**
+    <form class="contact-form" action="https://formspree.io/f/mreagwkd" method="POST">
+      <div class="field">
+        <label for="name">Name</label>
+        <input id="name" name="name" type="text" autocomplete="name" required>
+      </div>
+
+      <div class="field">
+        <label for="email">Email</label>
+        <input id="email" name="email" type="email" autocomplete="email" required>
+      </div>
+
+      <div class="field">
+        <label for="message">Message</label>
+        <textarea id="message" name="message" rows="6" required></textarea>
+      </div>
+
+      <button type="submit">Send</button>
+    </form>
+  </div>
+</div>
 
 <style>
-  /* Contact form styling that works in both light & dark mode. */
+  /* Contact form styling (explicitly supports Chirpy's light/dark toggle). */
   :root {
-    --cf-bg: rgba(255, 255, 255, 0.85);
-    --cf-border: rgba(0, 0, 0, 0.14);
-    --cf-border-focus: rgba(0, 0, 0, 0.28);
-    --cf-btn-bg: rgba(0, 0, 0, 0.04);
-    --cf-btn-bg-hover: rgba(0, 0, 0, 0.07);
+    --cf-bg: rgba(255, 255, 255, 0.92);
+    --cf-border: rgba(0, 0, 0, 0.18);
+    --cf-border-focus: rgba(0, 0, 0, 0.32);
+    --cf-btn-bg: rgba(0, 0, 0, 0.05);
+    --cf-btn-bg-hover: rgba(0, 0, 0, 0.08);
     --cf-btn-border: rgba(0, 0, 0, 0.18);
+    --cf-label: rgba(0, 0, 0, 0.70);
+    --cf-section: rgba(0, 0, 0, 0.80);
   }
 
-  /* Chirpy typically sets html[data-mode]. If it doesn't, the media query below still helps. */
+  /* If Chirpy forces a mode, respect it (this avoids the “system dark overrides forced light” bug). */
+  html[data-mode='light'] {
+    --cf-bg: rgba(255, 255, 255, 0.92);
+    --cf-border: rgba(0, 0, 0, 0.18);
+    --cf-border-focus: rgba(0, 0, 0, 0.32);
+    --cf-btn-bg: rgba(0, 0, 0, 0.05);
+    --cf-btn-bg-hover: rgba(0, 0, 0, 0.08);
+    --cf-btn-border: rgba(0, 0, 0, 0.18);
+    --cf-label: rgba(0, 0, 0, 0.70);
+    --cf-section: rgba(0, 0, 0, 0.80);
+  }
+
   html[data-mode='dark'] {
     --cf-bg: rgba(255, 255, 255, 0.04);
     --cf-border: rgba(255, 255, 255, 0.18);
@@ -30,22 +69,41 @@ layout: page
     --cf-btn-bg: rgba(255, 255, 255, 0.08);
     --cf-btn-bg-hover: rgba(255, 255, 255, 0.12);
     --cf-btn-border: rgba(255, 255, 255, 0.25);
+    --cf-label: rgba(255, 255, 255, 0.72);
+    --cf-section: rgba(255, 255, 255, 0.82);
   }
 
+  /* Fallback: if no explicit data-mode is present, follow system preference. */
   @media (prefers-color-scheme: dark) {
-    :root {
+    html:not([data-mode]) {
       --cf-bg: rgba(255, 255, 255, 0.04);
       --cf-border: rgba(255, 255, 255, 0.18);
       --cf-border-focus: rgba(255, 255, 255, 0.35);
       --cf-btn-bg: rgba(255, 255, 255, 0.08);
       --cf-btn-bg-hover: rgba(255, 255, 255, 0.12);
       --cf-btn-border: rgba(255, 255, 255, 0.25);
+      --cf-label: rgba(255, 255, 255, 0.72);
+      --cf-section: rgba(255, 255, 255, 0.82);
     }
   }
 
-  .contact-form {
-    max-width: 520px;
-    margin-top: 0.75rem;
+  .contact-block {
+    max-width: 560px;
+  }
+
+  .contact-section {
+    margin: 0 0 1.25rem 0;
+  }
+
+  .contact-section-title {
+    font-weight: 700;
+    font-size: 1.05rem;
+    margin: 0 0 0.5rem 0;
+    color: var(--cf-section);
+  }
+
+  .contact-email a {
+    font-size: 1.02rem;
   }
 
   .contact-form .field {
@@ -55,7 +113,9 @@ layout: page
   .contact-form label {
     display: block;
     font-weight: 600;
-    margin: 0 0 0.35rem 0;
+    font-size: 0.92rem;
+    margin: 0 0 0.4rem 0;
+    color: var(--cf-label);
   }
 
   .contact-form input,
@@ -75,12 +135,12 @@ layout: page
   }
 
   .contact-form button {
-    padding: 0.65rem 1.0rem;
+    padding: 0.65rem 1.05rem;
     border-radius: 0.6rem;
     border: 1px solid var(--cf-btn-border);
     background: var(--cf-btn-bg);
     color: inherit;
-    font-weight: 600;
+    font-weight: 700;
     cursor: pointer;
   }
 
@@ -88,22 +148,3 @@ layout: page
     background: var(--cf-btn-bg-hover);
   }
 </style>
-
-<form class="contact-form" action="https://formspree.io/f/mreagwkd" method="POST">
-  <div class="field">
-    <label for="name">Name</label>
-    <input id="name" name="name" type="text" autocomplete="name" required>
-  </div>
-
-  <div class="field">
-    <label for="email">Email</label>
-    <input id="email" name="email" type="email" autocomplete="email" required>
-  </div>
-
-  <div class="field">
-    <label for="message">Message</label>
-    <textarea id="message" name="message" rows="6" required></textarea>
-  </div>
-
-  <button type="submit">Send</button>
-</form>


### PR DESCRIPTION
Fixes two Contact page issues:

1) Light theme still losing input borders/background
- The previous CSS followed `prefers-color-scheme`, which can still be dark even when you toggle Chirpy into light mode.
- This PR makes `html[data-mode='light']` and `html[data-mode='dark']` authoritative, and only falls back to `prefers-color-scheme` when no explicit mode is set.

2) Typography hierarchy
- Section labels (Email/Form) now have a distinct size/weight from the field labels (Name/Email/Message).

No extra text added beyond the requested labels and existing form fields.