### PR TITLE
Simplify About page (remove Now/Links)

### DIFF
--- a/_tabs/about.md
+++ b/_tabs/about.md
@@ -10,12 +10,6 @@ I’m an SRE with 10+ years of experience, focused on building reliable, scalabl
 I’m also very interested in security and digital privacy, and how they intersect with modern infrastructure and everyday engineering.
 
 ## What you’ll find here
-- Engineering notes (practical, copy/paste-friendly)
-- Project writeups (what I built, trade-offs, results)
+- Notes on whatever I’m exploring (tech, security & privacy, finance, politics, sports, and more)
+- Build logs and project writeups (what I built, trade-offs, results)
 - Occasional updates
-
-## Now
-I’m currently focusing on building a clean personal site and turning it into a consistent blog.
-
-## Links
-- GitHub: https://github.com/mmoradi97


### PR DESCRIPTION
Removes the **Now** and **Links** sections from the About page and rephrases “What you’ll find here” to reflect broader interests beyond engineering.