### PR TITLE
Fix pinned privacy post date (date-only front matter)

### DIFF
--- a/_posts/2026-02-16-digital-privacy-the-quiet-superpower.md
+++ b/_posts/2026-02-16-digital-privacy-the-quiet-superpower.md
@@ -1,6 +1,6 @@
 ---
 title: "Digital Privacy: The Quiet Superpower"
-date: 2026-02-16 02:30:00 +0100
+date: 2026-02-16
 categories: [privacy]
 tags: [privacy, security, digital-rights]
 pin: true


### PR DESCRIPTION
Fixes the pinned privacy post not showing up on the site.

The post was merged with a future timestamp (`2026-02-16 02:30:00 +0100`), so the build that ran immediately after merge could exclude it.

This PR changes the front-matter to a date-only value (`2026-02-16`) so it renders immediately and triggers a rebuild.