### PR TITLE
Hide starter posts + force blank favicon

### DIFF
--- a/_includes_chirpy/head-custom.html
+++ b/_includes_chirpy/head-custom.html
@@ -2,12 +2,11 @@
   Custom additions to <head>.
 
   Favicon:
-  Some browsers ignore empty SVG data-URIs, so we explicitly override the theme's
-  favicon links with `data:,` (a standard “empty” favicon).
+  We want a truly "blank" favicon.
 
-  If you want a real favicon later, we can replace these with actual files.
+  Some browsers (notably Safari) can ignore empty SVG/data:, so we provide a
+  1x1 transparent PNG via a data-URI and override common favicon link rels.
 -->
-<link rel="icon" href="data:,">
-<link rel="shortcut icon" href="data:,">
-<link rel="apple-touch-icon" href="data:,">
-<meta name="msapplication-TileImage" content="data:,">
+<link rel="icon" type="image/png" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMB/6XfW1sAAAAASUVORK5CYII=">
+<link rel="shortcut icon" type="image/png" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMB/6XfW1sAAAAASUVORK5CYII=">
+<link rel="apple-touch-icon" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMB/6XfW1sAAAAASUVORK5CYII=">

--- a/_posts/2026-02-07-welcome.md
+++ b/_posts/2026-02-07-welcome.md
@@ -1,10 +1,6 @@
 ---
 title: "Welcome"
-date: 2026-02-07 21:00:00 +0100
+date: 2026-02-07
 categories: [site]
-tags: [welcome, jekyll]
+published: false
 ---
-
-Welcome to my blog.
-
-I’ll use this space for short notes and project writeups. For now, this is the first post to make sure everything is wired up correctly.

--- a/_posts/2026-02-12-site-stack.md
+++ b/_posts/2026-02-12-site-stack.md
@@ -1,14 +1,6 @@
 ---
 title: "How this site works"
-date: 2026-02-12 20:00:00 +0100
+date: 2026-02-12
 categories: [site]
-tags: [jekyll, github-pages]
+published: false
 ---
-
-This site is built with Jekyll and hosted on GitHub Pages.
-
-## Content
-Posts live in `_posts/` and use Markdown.
-
-## Theme
-I’m using the Chirpy theme to get a clean, blog-like layout with archives, tags, and categories.

--- a/_posts/2026-02-15-now.md
+++ b/_posts/2026-02-15-now.md
@@ -1,16 +1,6 @@
 ---
 title: "What I’m building right now"
-date: 2026-02-15 10:00:00 +0100
+date: 2026-02-15
 categories: [updates]
-tags: [now]
+published: false
 ---
-
-A quick snapshot of what I’m focusing on.
-
-## Current priorities
-- Improve this website’s structure and design
-- Publish a few practical engineering notes
-- Document projects with clear before/after results
-
-## Next
-I’ll add a proper Projects section with short case studies and links.


### PR DESCRIPTION
Removes the 3 starter posts from the live site and fixes the favicon.

Changes
- Unpublishes these posts (so they disappear from home/archives):
  - 2026-02-07-welcome.md
  - 2026-02-12-site-stack.md
  - 2026-02-15-now.md
- Forces a blank favicon by overriding common favicon rel tags with a 1x1 transparent PNG data-URI in `_includes_chirpy/head-custom.html`.

Note
- If you truly want the post files deleted from the repo (not just hidden), I can do that in a follow-up PR.