### PR TITLE
Fix favicon: disable PWA/service worker

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -22,6 +22,11 @@ avatar: "https://avatars.githubusercontent.com/u/72094509?v=4"
 # Chirpy theme (use the theme gem, not remote_theme)
 theme: jekyll-theme-chirpy
 
+# Disable PWA (Progressive Web App) and service worker
+# This prevents aggressive caching of favicon and other assets
+pwa:
+  enabled: false
+
 plugins:
   - jekyll-include-cache
   - jekyll-seo-tag


### PR DESCRIPTION
**This is the real fix for the persistent favicon issue.**

The problem: Chirpy theme has PWA (Progressive Web App) enabled by default, which includes a service worker that aggressively caches favicons and other assets. This is why the favicon persisted despite all previous attempts to remove it - the service worker was serving the cached version.

This PR adds:
```yaml
pwa:
  enabled: false
```

to `_config.yml` to disable the PWA/service worker feature entirely.

After this is merged and deployed:
1. The service worker will stop serving cached assets
2. The blank favicon from `head-custom.html` will take effect
3. Visitors may need to clear their browser's application cache once (Chrome DevTools → Application → Clear storage)