### PR TITLE
Actively unregister service worker and clear caches

### DIFF
--- a/_includes_chirpy/head-custom.html
+++ b/_includes_chirpy/head-custom.html
@@ -10,3 +10,27 @@
 <link rel="icon" type="image/png" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMB/6XfW1sAAAAASUVORK5CYII=">
 <link rel="shortcut icon" type="image/png" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMB/6XfW1sAAAAASUVORK5CYII=">
 <link rel="apple-touch-icon" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMB/6XfW1sAAAAASUVORK5CYII=">
+
+<!-- Unregister any existing service workers and clear caches -->
+<script>
+  if ('serviceWorker' in navigator) {
+    navigator.serviceWorker.getRegistrations().then(function(registrations) {
+      for (let registration of registrations) {
+        registration.unregister().then(function(success) {
+          if (success) {
+            console.log('Service worker unregistered successfully');
+          }
+        });
+      }
+    });
+    
+    // Clear all caches
+    if ('caches' in window) {
+      caches.keys().then(function(cacheNames) {
+        cacheNames.forEach(function(cacheName) {
+          caches.delete(cacheName);
+        });
+      });
+    }
+  }
+</script>

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,16 @@
+// Unregister this service worker immediately
+self.addEventListener('install', () => {
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((cacheNames) => {
+      return Promise.all(
+        cacheNames.map((cacheName) => caches.delete(cacheName))
+      );
+    }).then(() => {
+      return self.registration.unregister();
+    })
+  );
+});


### PR DESCRIPTION
**The nuclear option: actively kill the service worker**

Disabling PWA in config prevents NEW service workers from being created, but existing ones keep running. This PR:

1. Creates `sw.js` - a replacement service worker that:
   - Unregisters itself immediately
   - Clears all caches
   
2. Updates `_includes_chirpy/head-custom.html` to add JavaScript that:
   - Finds and unregisters ALL service workers on every page load
   - Clears all browser caches

This will forcibly remove the service worker from any browser that visits the site after this is deployed.

**After merge:** The first page load will unregister the service worker, and subsequent loads will finally show no favicon.