### PR TITLE
Override Chirpy's favicons.html directly

### DIFF
--- a/_includes/favicons.html
+++ b/_includes/favicons.html
@@ -1,0 +1,4 @@
+<!-- Override Chirpy's favicons.html to use blank favicons -->
+<link rel="icon" type="image/png" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMB/6XfW1sAAAAASUVORK5CYII=">
+<link rel="shortcut icon" type="image/png" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMB/6XfW1sAAAAASUVORK5CYII=">
+<link rel="apple-touch-icon" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMB/6XfW1sAAAAASUVORK5CYII=">


### PR DESCRIPTION
**THE ACTUAL REAL FIX THIS TIME**

Problem found: Chirpy's `_includes/head.html` loads favicons via:
```liquid
{% include_cached favicons.html %}
```

This file is in the theme gem and loads the theme's default favicons. We've been trying to override it in the wrong place (`_includes_chirpy/head-custom.html`), but Jekyll loads the theme's `favicons.html` FIRST.

This PR creates `_includes/favicons.html` in your repo, which Jekyll will use INSTEAD of the theme gem's version.

The file contains only blank favicon data URIs, so no external favicon files are loaded.

This directly replaces what Chirpy loads, so it will actually work.