### PR TITLE
Fix: Put favicons.html in correct _includes_chirpy directory

### DIFF
--- a/_includes_chirpy/favicons.html
+++ b/_includes_chirpy/favicons.html
@@ -1,0 +1,4 @@
+<!-- Override Chirpy's favicons.html to use blank favicons -->
+<link rel="icon" type="image/png" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMB/6XfW1sAAAAASUVORK5CYII=">
+<link rel="shortcut icon" type="image/png" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMB/6XfW1sAAAAASUVORK5CYII=">
+<link rel="apple-touch-icon" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMB/6XfW1sAAAAASUVORK5CYII=">


### PR DESCRIPTION
**FOUND THE ACTUAL ISSUE**

Your `_config.yml` has:
```yaml
includes_dir: _includes_chirpy
```

This tells Jekyll to look for includes in `_includes_chirpy/`, NOT `_includes/`.

PR #23 created `_includes/favicons.html`, but Jekyll wasn't looking there because of the custom includes directory.

This PR creates the file in the **correct location**: `_includes_chirpy/favicons.html`

Now when Chirpy does `{% include favicons.html %}`, Jekyll will find YOUR override file (with blank favicons) instead of the theme's default.