### PR TITLE
Privacy Watch: January 2026 post

### DIFF
--- a/_posts/2026-01-31-privacy-watch-january-2026-the-surveillance-tightens.md
+++ b/_posts/2026-01-31-privacy-watch-january-2026-the-surveillance-tightens.md
@@ -1,0 +1,63 @@
+---
+title: "Privacy Watch: January 2026 - The Surveillance Tightens"
+date: 2026-01-31 23:00:00 +0100
+categories: [privacy]
+tags: [privacy, data-breach, surveillance]
+series: "Privacy Watch"
+---
+
+January 2026 was a reminder that **privacy** isn’t something you “get” from a policy page or a new regulation — it’s something you lose quietly, then notice too late.
+
+This month’s story is not “good news” about new rules.
+It’s the same old pattern: more collection, more exposure, more pressure to normalize surveillance.
+
+## The breaches
+
+Big breaches are the visible part of the problem: they turn everyday accounts into permanent attack surface.
+
+- Instagram breach listing (data in the wild; check whether your email/phone is included): [Have I Been Pwned — Instagram](https://haveibeenpwned.com/Breach/Instagram)
+- Notable January 2026 breaches roundup: [Security Magazine — January 2026 breaches](https://www.securitymagazine.com/articles/102110-7-data-breaches-exposures-to-know-about-january-2026)
+
+**Why it matters:** once your identifiers (email, phone, handles) are out, you become easier to target with phishing, SIM swap attempts, doxxing, and credential stuffing.
+
+## The regulation headlines
+
+Regulatory updates can be real, but they don’t automatically reduce surveillance or stop data misuse.
+Often they change incentives: companies document more; users get more pop-ups; collection continues.
+
+- EU Data Protection Day 2026: [EDPS — Data Protection Day 2026](https://www.edps.europa.eu/data-protection/our-work/publications/events/2026-01-28-data-protection-day_en)
+- What to watch in 2026 (EU privacy/cyber): [Inside Privacy — Key 2026 developments](https://www.insideprivacy.com/european-union-2/what-to-watch-in-2026-key-eu-privacy-cybersecurity-developments/)
+
+## The surveillance reality check
+
+Three things can be true at once:
+
+1. Laws can improve accountability.
+2. Enforcement is slow.
+3. Your risk is immediate.
+
+Your practical threat model still includes:
+
+- Brokers and scrapers collecting identity fragments at scale.
+- Platforms designing defaults for growth, not minimization.
+- Governments pushing broader access to data “for safety,” then keeping it.
+
+If you want a mental model that holds up: treat your online identity like a long-lived identifier you can’t fully revoke.
+
+## What to do this month
+
+Pick 2–3 actions and actually do them.
+Doing everything once is better than doing nothing perfectly.
+
+- Turn on a password manager + change your most reused passwords.
+- Enable phishing-resistant 2FA where possible (passkeys or security keys; avoid SMS for important accounts).
+- Reduce your public exposure: remove phone number from public profiles; lock down who can find you by email/phone.
+- Audit logins: check “active sessions” / “devices” in your main accounts and sign out of everything you don’t recognize.
+- Minimize data: delete old accounts you don’t use; opt out of marketing where it’s offered; disable ad personalization.
+
+## Next Privacy Watch
+
+If you want, I’ll keep each month focused on:
+- What changed that increases risk.
+- The one or two moves that materially reduce exposure.
+


### PR DESCRIPTION
Adds the first post in the new monthly series **Privacy Watch**.

- Title: “Privacy Watch: January 2026 - The Surveillance Tightens”
- Tags: privacy, data-breach, surveillance
- Date set to end-of-month (2026-01-31) to match the “January 2026” issue

Next steps (optional): choose a cover image and add `image:` front matter once you’ve picked one.