### PR TITLE
Privacy Watch Jan 2026: add self-hosted images (SVG)

### DIFF
--- a/_posts/2026-01-31-privacy-watch-january-2026-the-surveillance-tightens.md
+++ b/_posts/2026-01-31-privacy-watch-january-2026-the-surveillance-tightens.md
@@ -4,6 +4,10 @@ date: 2026-01-31 23:00:00 +0100
 categories: [privacy]
 tags: [privacy, data-breach, surveillance]
 series: "Privacy Watch"
+img_path: /assets/img/posts/privacy-watch/2026-01/
+image:
+  path: pw-2026-01-cover.svg
+  alt: "Abstract digital surveillance network"
 ---
 
 January 2026 was a reminder that **privacy** isn’t something you “get” from a policy page or a new regulation — it’s something you lose quietly, then notice too late.
@@ -12,6 +16,9 @@ This month’s story is not “good news” about new rules.
 It’s the same old pattern: more collection, more exposure, more pressure to normalize surveillance.
 
 ## The breaches
+
+![Abstract data leak](breach-leak.svg)
+_Abstract data leak: when identifiers spill, they keep getting reused against you._
 
 Big breaches are the visible part of the problem: they turn everyday accounts into permanent attack surface.
 
@@ -29,6 +36,9 @@ Often they change incentives: companies document more; users get more pop-ups; c
 - What to watch in 2026 (EU privacy/cyber): [Inside Privacy — Key 2026 developments](https://www.insideprivacy.com/european-union-2/what-to-watch-in-2026-key-eu-privacy-cybersecurity-developments/)
 
 ## The surveillance reality check
+
+![Surveillance grid](surveillance-grid.svg)
+_Surveillance doesn’t need to be dramatic to be effective — it just needs to be normal._
 
 Three things can be true at once:
 
@@ -60,4 +70,3 @@ Doing everything once is better than doing nothing perfectly.
 If you want, I’ll keep each month focused on:
 - What changed that increases risk.
 - The one or two moves that materially reduce exposure.
-

--- a/assets/img/posts/privacy-watch/2026-01/breach-leak.svg
+++ b/assets/img/posts/privacy-watch/2026-01/breach-leak.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="675" viewBox="0 0 1200 675" role="img" aria-label="Abstract data leak">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#090f1f"/>
+      <stop offset="1" stop-color="#05070f"/>
+    </linearGradient>
+    <radialGradient id="drop" cx="55%" cy="40%" r="55%">
+      <stop offset="0" stop-color="#60a5fa" stop-opacity="0.18"/>
+      <stop offset="1" stop-color="#60a5fa" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+
+  <rect width="1200" height="675" fill="url(#bg)"/>
+  <rect width="1200" height="675" fill="url(#drop)"/>
+
+  <!-- stylized database -->
+  <g transform="translate(180,150)">
+    <ellipse cx="260" cy="70" rx="260" ry="58" fill="#0f172a" stroke="#93c5fd" opacity="0.8"/>
+    <path d="M0 70v210c0 32 116 58 260 58s260-26 260-58V70" fill="#0b1225" stroke="#93c5fd" opacity="0.75"/>
+    <ellipse cx="260" cy="280" rx="260" ry="58" fill="#0f172a" stroke="#93c5fd" opacity="0.8"/>
+
+    <path d="M80 140h360" stroke="#93c5fd" opacity="0.45"/>
+    <path d="M80 200h360" stroke="#93c5fd" opacity="0.35"/>
+
+    <!-- leak droplet -->
+    <path d="M520 120c28 42 48 70 48 98 0 34-28 62-62 62s-62-28-62-62c0-28 20-56 48-98 6-9 14-9 28 0z" fill="#60a5fa" opacity="0.85"/>
+    <circle cx="506" cy="228" r="10" fill="#e0f2fe" opacity="0.85"/>
+  </g>
+
+  <!-- warning lines -->
+  <g stroke="#60a5fa" opacity="0.35">
+    <path d="M720 120L1040 80"/>
+    <path d="M740 160L1100 180"/>
+    <path d="M710 210L1020 290"/>
+  </g>
+</svg>

--- a/assets/img/posts/privacy-watch/2026-01/pw-2026-01-cover.svg
+++ b/assets/img/posts/privacy-watch/2026-01/pw-2026-01-cover.svg
@@ -1,0 +1,80 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="900" viewBox="0 0 1600 900" role="img" aria-label="Abstract digital surveillance network">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0b1020"/>
+      <stop offset="1" stop-color="#05070f"/>
+    </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="45%" r="60%">
+      <stop offset="0" stop-color="#2dd4bf" stop-opacity="0.16"/>
+      <stop offset="1" stop-color="#2dd4bf" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur stdDeviation="3"/>
+    </filter>
+  </defs>
+
+  <rect width="1600" height="900" fill="url(#bg)"/>
+  <rect width="1600" height="900" fill="url(#glow)"/>
+
+  <!-- faint grid -->
+  <g opacity="0.08" stroke="#a7f3d0" stroke-width="1">
+    <path d="M0 120H1600"/>
+    <path d="M0 240H1600"/>
+    <path d="M0 360H1600"/>
+    <path d="M0 480H1600"/>
+    <path d="M0 600H1600"/>
+    <path d="M0 720H1600"/>
+    <path d="M140 0V900"/>
+    <path d="M320 0V900"/>
+    <path d="M500 0V900"/>
+    <path d="M680 0V900"/>
+    <path d="M860 0V900"/>
+    <path d="M1040 0V900"/>
+    <path d="M1220 0V900"/>
+    <path d="M1400 0V900"/>
+  </g>
+
+  <!-- connections -->
+  <g fill="none" stroke="#2dd4bf" stroke-width="2" opacity="0.35">
+    <path d="M240 650 C420 520, 520 470, 690 410"/>
+    <path d="M690 410 C860 350, 1020 360, 1180 290"/>
+    <path d="M520 210 C690 330, 860 460, 1010 540"/>
+    <path d="M1010 540 C1120 600, 1260 610, 1420 560"/>
+    <path d="M330 360 C510 330, 640 300, 820 240"/>
+    <path d="M820 240 C980 190, 1110 170, 1290 210"/>
+  </g>
+
+  <!-- nodes -->
+  <g>
+    <g filter="url(#soft)" opacity="0.55">
+      <circle cx="240" cy="650" r="10" fill="#2dd4bf"/>
+      <circle cx="690" cy="410" r="10" fill="#2dd4bf"/>
+      <circle cx="1180" cy="290" r="10" fill="#2dd4bf"/>
+      <circle cx="520" cy="210" r="10" fill="#2dd4bf"/>
+      <circle cx="1010" cy="540" r="10" fill="#2dd4bf"/>
+      <circle cx="1420" cy="560" r="10" fill="#2dd4bf"/>
+      <circle cx="330" cy="360" r="10" fill="#2dd4bf"/>
+      <circle cx="820" cy="240" r="10" fill="#2dd4bf"/>
+      <circle cx="1290" cy="210" r="10" fill="#2dd4bf"/>
+    </g>
+
+    <g opacity="0.95">
+      <circle cx="240" cy="650" r="6" fill="#e5fff9"/>
+      <circle cx="690" cy="410" r="6" fill="#e5fff9"/>
+      <circle cx="1180" cy="290" r="6" fill="#e5fff9"/>
+      <circle cx="520" cy="210" r="6" fill="#e5fff9"/>
+      <circle cx="1010" cy="540" r="6" fill="#e5fff9"/>
+      <circle cx="1420" cy="560" r="6" fill="#e5fff9"/>
+      <circle cx="330" cy="360" r="6" fill="#e5fff9"/>
+      <circle cx="820" cy="240" r="6" fill="#e5fff9"/>
+      <circle cx="1290" cy="210" r="6" fill="#e5fff9"/>
+    </g>
+  </g>
+
+  <!-- subtle title block (no words, just UI hint) -->
+  <g opacity="0.18" stroke="#e5fff9" fill="none">
+    <rect x="120" y="120" width="520" height="120" rx="18"/>
+    <path d="M160 160H590"/>
+    <path d="M160 195H480"/>
+  </g>
+</svg>

--- a/assets/img/posts/privacy-watch/2026-01/surveillance-grid.svg
+++ b/assets/img/posts/privacy-watch/2026-01/surveillance-grid.svg
@@ -1,0 +1,48 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="675" viewBox="0 0 1200 675" role="img" aria-label="Surveillance grid">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#070a12"/>
+      <stop offset="1" stop-color="#05070f"/>
+    </linearGradient>
+    <radialGradient id="pulse" cx="50%" cy="52%" r="55%">
+      <stop offset="0" stop-color="#22c55e" stop-opacity="0.10"/>
+      <stop offset="1" stop-color="#22c55e" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+
+  <rect width="1200" height="675" fill="url(#bg)"/>
+  <rect width="1200" height="675" fill="url(#pulse)"/>
+
+  <!-- grid -->
+  <g opacity="0.12" stroke="#86efac" stroke-width="1">
+    <path d="M0 90H1200"/>
+    <path d="M0 180H1200"/>
+    <path d="M0 270H1200"/>
+    <path d="M0 360H1200"/>
+    <path d="M0 450H1200"/>
+    <path d="M0 540H1200"/>
+    <path d="M120 0V675"/>
+    <path d="M240 0V675"/>
+    <path d="M360 0V675"/>
+    <path d="M480 0V675"/>
+    <path d="M600 0V675"/>
+    <path d="M720 0V675"/>
+    <path d="M840 0V675"/>
+    <path d="M960 0V675"/>
+    <path d="M1080 0V675"/>
+  </g>
+
+  <!-- eye -->
+  <g transform="translate(300,160)">
+    <path d="M300 180c-130 0-240 78-300 160 60 82 170 160 300 160s240-78 300-160c-60-82-170-160-300-160z" fill="#0b1220" stroke="#86efac" opacity="0.85"/>
+    <circle cx="300" cy="340" r="88" fill="#052e1b" stroke="#86efac" opacity="0.9"/>
+    <circle cx="300" cy="340" r="30" fill="#86efac" opacity="0.9"/>
+    <circle cx="330" cy="310" r="10" fill="#eafff0" opacity="0.7"/>
+
+    <!-- scan rings -->
+    <g fill="none" stroke="#22c55e" opacity="0.35">
+      <circle cx="300" cy="340" r="140"/>
+      <circle cx="300" cy="340" r="200"/>
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
Adds **self-hosted** images (SVG) for the Privacy Watch: January 2026 post.

Changes
- Adds `img_path` and a top preview `image:` (cover) to the post.
- Adds two in-post illustrations where applicable (breach + surveillance sections).
- Stores all images in `assets/img/posts/privacy-watch/2026-01/` as SVG so they can be versioned and hosted directly from the repo.

Notes
- No pinned posts were added/modified in this PR.