### PR TITLE
Fix: unpin post + repair Privacy Watch image paths

### DIFF
--- a/_posts/2026-01-31-privacy-watch-january-2026-the-surveillance-tightens.md
+++ b/_posts/2026-01-31-privacy-watch-january-2026-the-surveillance-tightens.md
@@ -4,9 +4,8 @@ date: 2026-01-31 23:00:00 +0100
 categories: [privacy]
 tags: [privacy, data-breach, surveillance]
 series: "Privacy Watch"
-img_path: /assets/img/posts/privacy-watch/2026-01/
 image:
-  path: pw-2026-01-cover.svg
+  path: /assets/img/posts/privacy-watch/2026-01/pw-2026-01-cover.svg
   alt: "Abstract digital surveillance network"
 ---
 
@@ -17,7 +16,7 @@ It’s the same old pattern: more collection, more exposure, more pressure to no
 
 ## The breaches
 
-![Abstract data leak](breach-leak.svg)
+![Abstract data leak](/assets/img/posts/privacy-watch/2026-01/breach-leak.svg)
 _Abstract data leak: when identifiers spill, they keep getting reused against you._
 
 Big breaches are the visible part of the problem: they turn everyday accounts into permanent attack surface.
@@ -37,7 +36,7 @@ Often they change incentives: companies document more; users get more pop-ups; c
 
 ## The surveillance reality check
 
-![Surveillance grid](surveillance-grid.svg)
+![Surveillance grid](/assets/img/posts/privacy-watch/2026-01/surveillance-grid.svg)
 _Surveillance doesn’t need to be dramatic to be effective — it just needs to be normal._
 
 Three things can be true at once:

--- a/_posts/2026-02-16-digital-privacy-the-quiet-superpower.md
+++ b/_posts/2026-02-16-digital-privacy-the-quiet-superpower.md
@@ -3,7 +3,6 @@ title: "Digital Privacy: The Quiet Superpower"
 date: 2026-02-16
 categories: [privacy]
 tags: [privacy, security, digital-rights]
-pin: true
 description: Privacy is autonomy, safety, and leverage—especially in a world that logs everything.
 image: https://commons.wikimedia.org/wiki/Special:FilePath/Cybersecurity.png
 ---


### PR DESCRIPTION
Fixes two issues:

1) Remove pinned behavior from “Digital Privacy: The Quiet Superpower” (deletes `pin: true`) so the homepage order is purely by latest post date.

2) Fix broken images for the Privacy Watch January 2026 post by switching cover + inline images to explicit `/assets/...` paths (so they load both on the landing page cards and inside the post page).

Notes
- Assets already exist under `assets/img/posts/privacy-watch/2026-01/`.
- No theme/layout changes; this is content-only and should be safe.