### PR TITLE
Fix: publish Privacy Watch now by setting time to 21:00 today

### DIFF
--- a/_posts/2026-01-31-privacy-watch-january-2026-the-surveillance-tightens.md
+++ b/_posts/2026-01-31-privacy-watch-january-2026-the-surveillance-tightens.md
@@ -1,6 +1,6 @@
 ---
 title: "Privacy Watch: January 2026 - The Surveillance Tightens"
-date: 2026-02-16 23:30:00 +0100
+date: 2026-02-16 21:00:00 +0100
 categories: [privacy]
 tags: [privacy, data-breach, surveillance]
 series: "Privacy Watch"


### PR DESCRIPTION
Set the **Privacy Watch** post time to `2026-02-16 21:00:00 +0100`.

This makes it:
- In the *past* relative to your current local time, so Jekyll will publish it immediately.
- Still later on the same day than **Digital Privacy** (`2026-02-16 12:00:00 +0100`), so it should appear above it on the homepage.

No content changes, only the `date` field.